### PR TITLE
Don't provide a namespace module

### DIFF
--- a/lib/rubysmith/builders/core.rb
+++ b/lib/rubysmith/builders/core.rb
@@ -23,7 +23,6 @@ module Rubysmith
           replace('  require', 'require').
           replace(/    (?=(Zeit|loader|end))/, '').
           replace("\n  \n", "\n\n").
-          insert_before("module #{module_name}", "#{indentation}# Main namespace.\n").
           replace("end\n  end", "    end\n  end")
 
         configuration

--- a/lib/rubysmith/templates/%project_name%/lib/%project_path%.rb.erb
+++ b/lib/rubysmith/templates/%project_name%/lib/%project_path%.rb.erb
@@ -11,4 +11,3 @@
     loader.setup
   <% end %>
 <% end %>
-<% namespace %>


### PR DESCRIPTION
Rather than structuring my rubysmith projects like a gem, where everything is within a namespace, I'm planning just to add classes at the "top level".