### PR TITLE
Don't include `/.bundle` in `.gitignore`

### DIFF
--- a/lib/rubysmith/templates/%project_name%/.gitignore.erb
+++ b/lib/rubysmith/templates/%project_name%/.gitignore.erb
@@ -1,4 +1,3 @@
-/.bundle
 <% if configuration.build_yard %>
   .yardoc
 <% end %>


### PR DESCRIPTION
Although a `.bundle` directory is sometimes used and should generally(/always?) be gitignored, it's relatively uncommon and not worth including here.